### PR TITLE
Fixing small issues

### DIFF
--- a/src/main/java/io/specto/swagger/hoverfly/RequestDetails.java
+++ b/src/main/java/io/specto/swagger/hoverfly/RequestDetails.java
@@ -11,17 +11,15 @@ public class RequestDetails {
     private final String destination;
     private final String scheme;
     private final String query;
-    private final String body;
     private final Map<String, List<String>> headers;
 
-    private RequestDetails(String requestType, String path, String method, String destination, String scheme, String query, String body, Map<String, List<String>> headers) {
+    private RequestDetails(String requestType, String path, String method, String destination, String scheme, String query, Map<String, List<String>> headers) {
         this.requestType = requestType;
         this.path = path;
         this.method = method;
         this.destination = destination;
         this.scheme = scheme;
         this.query = query;
-        this.body = body;
         this.headers = headers;
     }
 
@@ -49,10 +47,6 @@ public class RequestDetails {
         return query;
     }
 
-    public String getBody() {
-        return body;
-    }
-
     public Map<String, List<String>> getHeaders() {
         return headers;
     }
@@ -76,7 +70,6 @@ public class RequestDetails {
         private String path = "";
         private String method = "";
         private String destination;
-        private String body = "";
         private String query = "";
 
         public Builder withPath(final String path) {
@@ -98,13 +91,8 @@ public class RequestDetails {
             return this;
         }
 
-        public Builder withBody(final String body) {
-            this.body = body;
-            return this;
-        }
-
         public RequestDetails build() {
-            return new RequestDetails(requestType, path, method, destination, SCHEME, query, body, Collections.emptyMap());
+            return new RequestDetails(requestType, path, method, destination, SCHEME, query, Collections.emptyMap());
         }
 
         public Builder withQuery(final String query) {

--- a/src/main/java/io/specto/swagger/hoverfly/ResponseDetails.java
+++ b/src/main/java/io/specto/swagger/hoverfly/ResponseDetails.java
@@ -1,6 +1,7 @@
 package io.specto.swagger.hoverfly;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,14 +42,25 @@ public class ResponseDetails {
 
         private String body = "";
         private int status = 200;
+        Map<String, List<String>> headers = new LinkedHashMap<String, List<String>>();
 
         public Builder withBody(final String body) {
             this.body = body;
             return this;
         }
 
+        public Builder withHeaders(final Map<String, List<String>> headers) {
+            this.headers = headers;
+            return this;
+        }
+        
+        public Builder addHeader(final String key, List<String> values) {
+            this.headers.put(key, values);
+            return this;
+        }
+
         public ResponseDetails build() {
-            return new ResponseDetails(status, body, false, Collections.emptyMap());
+            return new ResponseDetails(status, body, false, headers);
         }
 
         public Builder withStatus(final int status) {

--- a/src/test/resources/petstore-output.json
+++ b/src/test/resources/petstore-output.json
@@ -8,14 +8,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "{\"id\":\"0\",\"category\":{\"id\":\"0\",\"name\":\"string\"},\"name\":\"doggie\",\"photoUrls\":[\"string\"],\"tags\":[{\"id\":\"0\",\"name\":\"string\"}],\"status\":\"available\"}",
         "headers" : { }
       },
       "response" : {
         "status" : 400,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -25,14 +24,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "{\"id\":\"0\",\"category\":{\"id\":\"0\",\"name\":\"string\"},\"name\":\"doggie\",\"photoUrls\":[\"string\"],\"tags\":[{\"id\":\"0\",\"name\":\"string\"}],\"status\":\"available\"}",
         "headers" : { }
       },
       "response" : {
         "status" : 405,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -41,15 +39,14 @@
         "method" : "GET",
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
-        "query" : "?status=available",
-        "body" : "",
+        "query" : "status=available",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "[{\"id\":\"0\",\"category\":{\"id\":\"0\",\"name\":\"string\"},\"name\":\"doggie\",\"photoUrls\":[\"string\"],\"tags\":[{\"id\":\"0\",\"name\":\"string\"}],\"status\":\"available\"}]",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -58,15 +55,14 @@
         "method" : "GET",
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
-        "query" : "?tags=string",
-        "body" : "",
+        "query" : "tags=string",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "[{\"id\":\"0\",\"category\":{\"id\":\"0\",\"name\":\"string\"},\"name\":\"doggie\",\"photoUrls\":[\"string\"],\"tags\":[{\"id\":\"0\",\"name\":\"string\"}],\"status\":\"available\"}]",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -76,14 +72,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 405,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -93,14 +88,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 400,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -110,14 +104,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "{\"id\":\"0\",\"category\":{\"id\":\"0\",\"name\":\"string\"},\"name\":\"doggie\",\"photoUrls\":[\"string\"],\"tags\":[{\"id\":\"0\",\"name\":\"string\"}],\"status\":\"available\"}",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -127,14 +120,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "{\"code\":\"0\",\"type\":\"string\",\"message\":\"string\"}",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -144,14 +136,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "\"{}\"",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -161,14 +152,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "{\"id\":\"0\",\"petId\":\"0\",\"quantity\":\"0\",\"shipDate\":\"\",\"status\":\"placed\",\"complete\":\"\"}",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "{\"id\":\"0\",\"petId\":\"0\",\"quantity\":\"0\",\"shipDate\":\"\",\"status\":\"placed\",\"complete\":\"\"}",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -178,14 +168,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 400,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -195,14 +184,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "{\"id\":\"0\",\"petId\":\"0\",\"quantity\":\"0\",\"shipDate\":\"\",\"status\":\"placed\",\"complete\":\"\"}",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -212,14 +200,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "{\"id\":\"0\",\"username\":\"string\",\"firstName\":\"string\",\"lastName\":\"string\",\"email\":\"string\",\"password\":\"string\",\"phone\":\"string\",\"userStatus\":\"0\"}",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -229,14 +216,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -246,14 +232,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -263,14 +248,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "\"string\"",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -280,14 +264,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -297,14 +280,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "{\"id\":\"0\",\"username\":\"string\",\"firstName\":\"string\",\"lastName\":\"string\",\"email\":\"string\",\"password\":\"string\",\"phone\":\"string\",\"userStatus\":\"0\"}",
         "headers" : { }
       },
       "response" : {
         "status" : 400,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -314,14 +296,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 400,
         "body" : "",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     }, {
       "request" : {
@@ -331,14 +312,13 @@
         "destination" : "petstore.swagger.io",
         "scheme" : "http",
         "query" : "",
-        "body" : "",
         "headers" : { }
       },
       "response" : {
         "status" : 200,
         "body" : "{\"id\":\"0\",\"username\":\"string\",\"firstName\":\"string\",\"lastName\":\"string\",\"email\":\"string\",\"password\":\"string\",\"phone\":\"string\",\"userStatus\":\"0\"}",
         "encodedBody" : false,
-        "headers" : { }
+        "headers": { "Content-Type" : [ "application/json" ]}
       }
     } ]
   },

--- a/src/test/resources/simple-swagger-output.json
+++ b/src/test/resources/simple-swagger-output.json
@@ -9,13 +9,12 @@
           "destination": "specto.io",
           "scheme": "http",
           "query": "",
-          "body": "",
           "headers": {}
         },
         "response": {
           "status": 200,
           "encodedBody": false,
-          "headers": {}
+          "headers": { "Content-Type" : [ "application/json" ]}
         }
       }
     ]


### PR DESCRIPTION
- If a definition contains an example that is returned instead of listing the properties (even works for an array that contains a specified type)
- Fixed an error where a definition of type array (that did not have any properties) caused an exception
- Removed the log-message that was written top of the output
- Removed the matching on request body so that there is a match on all bodies. (Same as in Hoverfly Cloud)
- Added response header Content-Type=application/json
- Removed “?” from the request query.